### PR TITLE
improve perceived performance

### DIFF
--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -102,23 +102,32 @@ export const main = async () => {
   const calendarEl = document.querySelector(".neoncrm-calendar #calendar");
   const categoriesEl = document.querySelector(".neoncrm-calendar .categories");
   const calendar = renderCalendar(calendarEl);
-  let events = await getEvents();
-  document.querySelector(".neoncrm-calendar .loading").remove();
-
-  let calendarEvents = events.map((event) => addEvent(calendar, event));
+  let calendarEvents = [];
+  let events = [];
+  getEvents().then((evs) => {
+    document.querySelector(".neoncrm-calendar .loading").remove();
+    if (calendarEvents.length) {
+      // if the events with categories already rendered, don't overwrite
+      return;
+    }
+    events = evs;
+    calendarEvents = events.map((event) => addEvent(calendar, event));
+  });
 
   if (categoriesEl) {
-    events = await getEventsWithCategories();
-    calendarEvents.map((calendarEvent) => calendarEvent.remove());
-    calendarEvents = events.map((event) => addEvent(calendar, event));
-    const categoryNames = getCategories(events);
-    renderCategories(categoriesEl, categoryNames, {
-      onChange: (category) => {
-        calendarEvents.map((calendarEvent) => calendarEvent.remove());
-        calendarEvents = events
-          .filter((event) => ["All", event.category].includes(category))
-          .map((event) => addEvent(calendar, event));
-      },
+    getEventsWithCategories().then((evs) => {
+      events = evs;
+      calendarEvents.map((calendarEvent) => calendarEvent.remove());
+      calendarEvents = events.map((event) => addEvent(calendar, event));
+      const categoryNames = getCategories(events);
+      renderCategories(categoriesEl, categoryNames, {
+        onChange: (category) => {
+          calendarEvents.map((calendarEvent) => calendarEvent.remove());
+          calendarEvents = events
+            .filter((event) => ["All", event.category].includes(category))
+            .map((event) => addEvent(calendar, event));
+        },
+      });
     });
   }
 };

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -15,13 +15,6 @@ add_action( 'rest_api_init', function() {
 	) );
 } );
 
-add_action( 'rest_api_init', function() {
-	register_rest_route( 'neoncrm-calendar/v1', '/categories', array(
-		'methods'  => 'GET',
-		'callback' => 'neoncrm_calendar_rest_get_categories',
-	) );
-} );
-
 function neoncrm_calendar_get_from_cache($cache_key, $url, $args) {
     $key = 'neoncrm_' . $cache_key . '_' . md5( json_encode($args) );
     $cached = get_transient( $key );
@@ -126,8 +119,7 @@ function neoncrm_calendar_rest_get_events( WP_REST_Request $request ) {
         ],
         'pagination' => [
             'currentPage' => 0,
-            // todo paginate
-            'pageSize' => 20,
+            'pageSize' => 200,
             'sortColumn' => 'Event Start Date',
             'sortDirection' => 'ASC',
         ]
@@ -138,36 +130,11 @@ function neoncrm_calendar_rest_get_events( WP_REST_Request $request ) {
             'Content-Type' => 'application/json'
         ),
         'body' => json_encode($data),
-        'timeout' => 15
+        'timeout' => 30
     );
     $events = neoncrm_calendar_get_from_cache('search', 'https://api.neoncrm.com/v2/events/search', $args);
     if ( empty ($events["searchResults"]) ) {
         return new WP_Error( 'no_events', 'Could not get events from Neon CRM', array( 'status' => 500 ) );
     }
     return rest_ensure_response($events);
-}
-
-function neoncrm_calendar_rest_get_categories( WP_REST_Request $request ) {
-    // todo before action validate keys in both routes
-	$api_key = neoncrm_calendar_get_option( 'neoncrm_api_key', '' );
-	$org_id  = neoncrm_calendar_get_option( 'neoncrm_org_id', '' );
-	if ( empty( $api_key ) ) {
-		return new WP_Error( 'no_api_key', 'API key not configured', array( 'status' => 500 ) );
-	}
-    if ( empty( $org_id ) ) {
-        return new WP_Error( 'no_org_id', 'Org ID not configured', array( 'status' => 500 ) );
-    }
-    $base = 'https://api.neoncrm.com/v2/events/categories';
-    $args = array(
-        'headers' => array(
-            'Authorization' => 'Basic ' . base64_encode( $org_id . ':' . $api_key ),
-            'Content-Type' => 'application/json'
-        ),
-        'timeout' => 15
-    );
-    $categories = neoncrm_calendar_get_from_cache('categories','https://api.neoncrm.com/v2/events/categories', $args);
-    if ( empty ($categories) ) {
-        return new WP_Error( 'no_events', 'Could not get categories from Neon CRM', array( 'status' => 500 ) );
-    }
-    return rest_ensure_response($categories);
 }

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -2,6 +2,13 @@
 defined( 'ABSPATH' ) || exit;
 
 add_action( 'rest_api_init', function() {
+	register_rest_route( 'neoncrm-calendar/v1', '/listEvents', array(
+		'methods'  => 'GET',
+		'callback' => 'neoncrm_calendar_rest_list_events',
+	) );
+} );
+
+add_action( 'rest_api_init', function() {
 	register_rest_route( 'neoncrm-calendar/v1', '/events', array(
 		'methods'  => 'GET',
 		'callback' => 'neoncrm_calendar_rest_get_events',
@@ -43,6 +50,39 @@ function neoncrm_calendar_get_from_cache($cache_key, $url, $args) {
     return new WP_Error( 'neon_error', $decoded, array( 'status' => $code ) );
 }
 
+function neoncrm_calendar_rest_list_events( WP_REST_Request $request ) {
+    // todo before action validate keys in both routes
+	$api_key = neoncrm_calendar_get_option( 'neoncrm_api_key', '' );
+	$org_id  = neoncrm_calendar_get_option( 'neoncrm_org_id', '' );
+	if ( empty( $api_key ) ) {
+		return new WP_Error( 'no_api_key', 'API key not configured', array( 'status' => 500 ) );
+	}
+    if ( empty( $org_id ) ) {
+        return new WP_Error( 'no_org_id', 'Org ID not configured', array( 'status' => 500 ) );
+    }
+    $base = 'https://api.neoncrm.com/v2/events';
+    $args = array(
+        'headers' => array(
+            'Authorization' => 'Basic ' . base64_encode( $org_id . ':' . $api_key ),
+            'Content-Type' => 'application/json'
+        ),
+        'timeout' => 15
+    );
+    $start_date = gmdate('Y-m-d', strtotime('-1 month'));
+    $end_date = gmdate('Y-m-d', strtotime('+3 month'));
+    $params = array(
+        'startDateAfter=' . rawurlencode( $start_date ),
+        'endDateBefore=' . rawurlencode( $end_date ),
+        'pageSize=200',
+    );
+    $neon_events_url = $base . '?' . implode( '&', $params );
+    $events = neoncrm_calendar_get_from_cache('listEvents', $neon_events_url, $args);
+    if ( empty ($events) ) {
+        return new WP_Error( 'no_events', 'Could not get events from Neon CRM', array( 'status' => 500 ) );
+    }
+    return rest_ensure_response($events);
+}
+
 function neoncrm_calendar_rest_get_events( WP_REST_Request $request ) {
     // todo before action validate keys in both routes
 	$api_key = neoncrm_calendar_get_option( 'neoncrm_api_key', '' );
@@ -55,7 +95,6 @@ function neoncrm_calendar_rest_get_events( WP_REST_Request $request ) {
     }
     $start_date = gmdate('Y-m-d', strtotime('-1 month'));
     $end_date = gmdate('Y-m-d', strtotime('+3 month'));
-    $base = 'https://api.neoncrm.com/v2/events/search/outputFields';
     $data = [
         'searchFields' => [
             [

--- a/templates/calendar.php
+++ b/templates/calendar.php
@@ -1,7 +1,7 @@
 <div class="neoncrm-calendar">
 	<div class="loading"></div>
 	<?php if ( 'true' === $atts['filter_categories'] ) : ?>
-	<div class="categories"></div>
+	<div class="categories">Loading categories...</div>
 	<?php endif; ?>
 	<div id="calendar"></div>
 </div>

--- a/tests/js/calendar.test.js
+++ b/tests/js/calendar.test.js
@@ -41,6 +41,19 @@ describe("formatEvents", () => {
   });
 });
 
+describe("getCategories", () => {
+  it("extracts unique categories from events", () => {
+    const events = [
+      { category: "Workshop" },
+      { category: "Seminar" },
+      { category: "Workshop" },
+      { category: null },
+      {},
+    ];
+    expect(getCategories(events)).toEqual(["Seminar", "Workshop"]);
+  });
+});
+
 describe("renderCategories", () => {
   it("renders category buttons", () => {
     const categoriesEl = document.createElement("div");
@@ -118,7 +131,7 @@ describe("renderCalendar", () => {
 describe("getEvents", () => {
   it("fetches and formats events", async () => {
     const mockResponse = {
-      searchResults: [{ "Event Name": "Sample Event" }],
+      events: [{ "Event Name": "Sample Event" }],
     };
     global.fetch = vi.fn(() =>
       Promise.resolve({

--- a/tests/php/EnqueueTest.php
+++ b/tests/php/EnqueueTest.php
@@ -50,15 +50,15 @@ class EnqueueTest extends WP_UnitTestCase {
 
     public function test_filter_categories_atts() {
         $this->assertStringNotContainsString(
-            '<div class="categories"></div>',
+            '<div class="categories">',
             do_shortcode('[neoncrm_calendar]')
         );
         $this->assertStringNotContainsString(
-            '<div class="categories"></div>',
+            '<div class="categories">',
             do_shortcode('[neoncrm_calendar filter_categories="false"]')
         );
         $this->assertStringContainsString(
-            '<div class="categories"></div>',
+            '<div class="categories">',
             do_shortcode('[neoncrm_calendar filter_categories="true"]')
         );
     }

--- a/tests/php/RestTest.php
+++ b/tests/php/RestTest.php
@@ -14,6 +14,22 @@ class RestTest extends WP_UnitTestCase {
         parent::tearDown();
     }
 
+    public function test_happy_path_list_events() {
+        add_filter('pre_http_request', function($response, $args, $url) {
+            if (strpos($url, 'events') !== false) {
+                return array(
+                    'response' => array( 'code' => 200 ),
+                    'body' => json_encode( array( 'events' => array(
+                        array( 'id' => 1, 'name' => 'Event 1', 'startDate' => '2024-06-01', 'endDate' => '2024-06-01' ),
+                    ) ) ) );
+            }
+            return new WP_Error('unexpected_url', 'Unexpected URL: ' . $url);
+        }, 10, 3 );
+        $response = neoncrm_calendar_rest_list_events( new WP_REST_Request() );
+        $this->assertIsArray( $response->data['events'] );
+        $this->assertCount( 1, $response->data['events'] );
+    }
+
     public function test_happy_path_events() {
         add_filter('pre_http_request', function($response, $args, $url) {
             if (strpos($url, 'events') !== false) {
@@ -28,22 +44,6 @@ class RestTest extends WP_UnitTestCase {
         $response = neoncrm_calendar_rest_get_events( new WP_REST_Request() );
         $this->assertIsArray( $response->data['searchResults'] );
         $this->assertCount( 1, $response->data['searchResults'] );
-    }
-
-    public function test_happy_path_categories() {
-        add_filter('pre_http_request', function($response, $args, $url) {
-            if (strpos($url, 'categories') !== false) {
-                return array(
-                    'response' => array( 'code' => 200 ),
-                    'body' => json_encode(array(
-                        array( 'id' => 1, 'name' => 'Category 1' ),
-                    ) ) );
-            }
-            return new WP_Error('unexpected_url', 'Unexpected URL: ' . $url);
-        }, 10, 3 );
-        $response = neoncrm_calendar_rest_get_categories( new WP_REST_Request() );
-        $this->assertIsArray( $response->data );
-        $this->assertCount( 1, $response->data );
     }
 
 	public function test_api_key_error() {


### PR DESCRIPTION
Fetching events with categories is expensive. First get events without categories, then replace them.